### PR TITLE
Add parse props for JSON parsing

### DIFF
--- a/dist/bundle.cjs.js
+++ b/dist/bundle.cjs.js
@@ -1249,6 +1249,10 @@ var script = {
         previewMode: {
             type: Boolean,
             'default': false
+        },
+        parse: {
+            type: Boolean,
+            'default': false
         }
     },
     provide: function provide() {
@@ -1278,6 +1282,16 @@ var script = {
                 timeout: timeout || 2000,
                 align: align
             };
+        },
+        parseValue: function parseValue() {
+            if (!this.parse || typeof this.value !== 'string') {
+                return this.value;
+            }
+            try {
+                return JSON.parse(this.value);
+            } catch (_unused) {
+                return this.value;
+            }
         }
     },
     watch: {
@@ -1364,7 +1378,7 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
             ])
         }, [vue.createVNode(_component_json_box, {
                 ref: 'jsonBox',
-                value: $props.value,
+                value: $options.parseValue,
                 sort: $props.sort,
                 'preview-mode': $props.previewMode
             }, null, 8, [

--- a/dist/bundle.esm.js
+++ b/dist/bundle.esm.js
@@ -1245,6 +1245,10 @@ var script = {
         previewMode: {
             type: Boolean,
             'default': false
+        },
+        parse: {
+            type: Boolean,
+            'default': false
         }
     },
     provide: function provide() {
@@ -1274,6 +1278,16 @@ var script = {
                 timeout: timeout || 2000,
                 align: align
             };
+        },
+        parseValue: function parseValue() {
+            if (!this.parse || typeof this.value !== 'string') {
+                return this.value;
+            }
+            try {
+                return JSON.parse(this.value);
+            } catch (_unused) {
+                return this.value;
+            }
         }
     },
     watch: {
@@ -1360,7 +1374,7 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
             ])
         }, [createVNode(_component_json_box, {
                 ref: 'jsonBox',
-                value: $props.value,
+                value: $options.parseValue,
                 sort: $props.sort,
                 'preview-mode': $props.previewMode
             }, null, 8, [

--- a/src/Components/json-viewer.vue
+++ b/src/Components/json-viewer.vue
@@ -8,7 +8,7 @@
       </span>
     </div>
     <div class="jv-code" :class="{ open: expandCode, boxed }">
-      <json-box ref="jsonBox" :value="value" :sort="sort" :preview-mode="previewMode" />
+      <json-box ref="jsonBox" :value="parseValue" :sort="sort" :preview-mode="previewMode" />
     </div>
     <div v-if="expandableCode && boxed" class="jv-more" @click="toggleExpandCode">
       <span class="jv-toggle" :class="{ open: !!expandCode }" />
@@ -63,6 +63,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    parse: {
+      type: Boolean,
+      default: false,
+    }
   },
   provide() {
     return {
@@ -93,6 +97,16 @@ export default {
         align,
       };
     },
+    parseValue() {
+      if (!this.parse || typeof this.value !== 'string') {
+        return this.value;
+      }
+      try {
+        return JSON.parse(this.value);
+      } catch {
+        return this.value;
+      }
+    }
   },
   watch: {
     value() {


### PR DESCRIPTION
## Issue
#22 

You can use the test cases below.

If I'm missing something, please let me know.

```js
<template>
  <JsonViewer :value="jsonData" copyable boxed sort theme="light"  @onKeyClick="keyClick"/>
  <!-- example parse -->
  <JsonViewer parse :value="jsonStringData" copyable boxed sort theme="dark"  @onKeyClick="keyClick"/>
</template>

<script setup>
  let obj = {
    name: "qiu",//string
    age: 18,//Array
    isMan:false,//boolean
    date:new Date(),
    fn:()=>{},
    arr:[1,2,5],
    reg:/ab+c/i
  };
  const jsonData = reactive(obj);
  const jsonStringData = reactive(obj);
</script>
```

I'm happy to contribute the feature.